### PR TITLE
Fix keda module name prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ module-image: docker-build docker-push ## Build the Module Image and push it to 
 .PHONY: module-build
 module-build: kyma kustomize ## Build the Module and push it to a registry defined in MODULE_REGISTRY
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	@$(KYMA) alpha create module --channel=${MODULE_CHANNEL} --name kyma.project.io/module/$(MODULE_NAME) --version $(MODULE_VERSION) --path . $(MODULE_CREATION_FLAGS)
+	@$(KYMA) alpha create module --channel=${MODULE_CHANNEL} --name kyma-project.io/module/$(MODULE_NAME) --version $(MODULE_VERSION) --path . $(MODULE_CREATION_FLAGS)
 
 ##@ Tools
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See also:
 You should get a result similar to this example:
 
    ```json
-   {"repositories":["keda-manager-dev-local","unsigned/component-descriptors/kyma.project.io/module/keda"]}
+   {"repositories":["keda-manager-dev-local","unsigned/component-descriptors/kyma-project.io/module/keda"]}
    ```
 6. Inspect the generated module template.
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -36,5 +36,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: localhost:5001/unsigned/kyma.project.io/module/keda
+  newName: localhost:5001/unsigned/kyma-project.io/module/keda
   newTag: 0.0.1


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- keda component should be named with `kyma-project.io`
