### PR TITLE
Add make target to render keda-manager manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ charts
 default.yaml
 template.yaml
 template-k3d.yaml
+keda-manager.yaml
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,11 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
+.PHONY: render-manifest
+render-manifest: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default > keda-manager.yaml
+
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with IGNORE_NOT_FOUND=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(IGNORE_NOT_FOUND) -f -

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: render-manifest
-render-manifest: manifests kustomize ## Render keda-manager.yaml manifest
+render-manifest: manifests kustomize ## Render keda-manager.yaml manifest.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > keda-manager.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: render-manifest
-render-manifest: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+render-manifest: manifests kustomize ## Render keda-manager.yaml manifest
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > keda-manager.yaml
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: k3d-kyma-registry:5001/unsigned/operator-images/keda-operator
+  newName: k3d-kyma-registry:5001/keda-manager-dev-local
   newTag: 0.0.2

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: k3d-kyma-registry:5001/keda-manager-dev-local
-  newTag: 0.0.1
+  newName: k3d-kyma-registry:5001/unsigned/operator-images/keda-operator
+  newTag: 0.0.2

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -48,7 +48,9 @@ hyperscalers-compatibility-test: ## Hyperscalers compatibility tests not impleme
 upgrade-to: ## Install Keda onto existing k3d cluster.
 	@make -C ${PROJECT_COMMON} reinstall-keda
 
-### Internal Dependencies
+.PHONY: render-manifest
+render-manifest:
+	@make -C ${PROJECT_ROOT} render-manifest
 
 .PHONY: run-with-lifecycle-manager
 run-with-lifecycle-manager:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add make target to render keda manager manifest yaml file. Such target is quite handy in generating `keda-manager.yaml` release artifact

 see [here](https://github.com/kyma-project/keda-manager/releases/tag/v0.0.1)
