### PR TITLE
Use latest golang in builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.1 as builder
+FROM golang:1.20.3 as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use latest golang to mitigate protecode findings

**Related issue(s)**
https://github.com/kyma-project/keda-manager/issues/10