### PR TITLE
Bump golang-runtime to 1.20.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.3 as builder
+FROM golang:1.20.4 as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump golang runtime to exclude potential vulnerabilities

**Related issue(s)**
CVE-2023-24540, CVE-2023-29400, CVE-2023-24539