### PR TITLE
Remove helm escaping in UI config

### DIFF
--- a/config/ui-extensions/scaledobjects/general
+++ b/config/ui-extensions/scaledobjects/general
@@ -7,5 +7,5 @@ category: Workloads
 name: Scaled Objects
 scope: namespace
 description: >-
-  {{`{{[Scaled Objects](https://keda.sh/docs/2.8/concepts/scaling-deployments/#scaledobject-spec)}}
-  describes which workloads should KEDA scale and what the triggers for the scaling are.`}}
+  {{[Scaled Objects](https://keda.sh/docs/2.8/concepts/scaling-deployments/#scaledobject-spec)}}
+  describes which workloads should KEDA scale and what the triggers for the scaling are.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- No helm templating is involved in keda installation - the extra escaping is not needed (as it causes errors in the UI)
