### PR TITLE
Use keda images synced into europe-docker.pkg.dev/kyma-project

### DIFF
--- a/keda.yaml
+++ b/keda.yaml
@@ -9527,7 +9527,7 @@ spec:
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
-          image: "ghcr.io/kedacore/keda:2.10.1"
+          image: "europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/kedacore/keda:2.10.1"
           command:
           - "/keda"
           args:
@@ -9642,7 +9642,7 @@ spec:
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
-          image: "ghcr.io/kedacore/keda-metrics-apiserver:2.10.1"
+          image: "europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/kedacore/keda-metrics-apiserver:2.10.1"
           imagePullPolicy: Always
           livenessProbe:
             httpGet:
@@ -9757,7 +9757,7 @@ spec:
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
-          image: "ghcr.io/kedacore/keda-admission-webhooks:2.10.1"
+          image: "europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/kedacore/keda-admission-webhooks:2.10.1"
           command:
           - /keda-admission-webhooks
           args:

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,9 +1,9 @@
 module-name: keda-manager
 protecode:
-  - eu.gcr.io/kyma-project/keda-manager:v20230405-03a2ca00
-  - ghcr.io/kedacore/keda:2.10.1
-  - ghcr.io/kedacore/keda-admission-webhooks:2.10.1
-  - ghcr.io/kedacore/keda-metrics-apiserver:2.10.1
+  - europe-docker.pkg.dev/kyma-project/prod/keda-manager:v20230516-35a38a26
+  - europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/kedacore/keda:2.10.1
+  - europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/kedacore/keda-admission-webhooks:2.10.1
+  - europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/kedacore/keda-metrics-apiserver:2.10.1
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- reference kyeda images from `europe-docker.pkg.dev/kyma-project` in the keda manifest
- change images in the security scanners config

**Related issue(s)**
#157 