### PR TITLE
Assume Deployment as a default scaledTargetRef.kind

### DIFF
--- a/config/ui-extensions/scaledobjects/details
+++ b/config/ui-extensions/scaledobjects/details
@@ -16,14 +16,14 @@ body:
         widget: Panel
         children:
           - name: Kind
-            source: spec.scaleTargetRef.kind
+            source: spec.scaleTargetRef.kind?spec.scaleTargetRef.kind:"Deployment"
           - name: Name
             source: spec.scaleTargetRef.name
             widget: ResourceLink
             resource:
               name: spec.scaleTargetRef.name
               namespace: $root.metadata.namespace
-              kind: spec.scaleTargetRef.kind
+              kind: spec.scaleTargetRef.kind?spec.scaleTargetRef.kind:"Deployment"
       - name: Scale Config
         widget: Panel
         children:

--- a/config/ui-extensions/scaledobjects/list
+++ b/config/ui-extensions/scaledobjects/list
@@ -1,5 +1,5 @@
 - name: Target
-  source: $join([spec.scaleTargetRef.name, ' (', spec.scaleTargetRef.kind, ')'])
+  source: $join([spec.scaleTargetRef.name, ' (', spec.scaleTargetRef.kind?spec.scaleTargetRef.kind:"Deployment", ')'])
 - name: Triggers
   source: spec.triggers[].type
   widget: JoinedArray


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- In Keda 2.10.x the `Deployment` is a default scaledTargetREf.kind and in this case its not rendered in the spec. Fix UI for such case