### PR TITLE
Define resources for keda-manager workload

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,7 +51,12 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        # TODO(user): Configure the resources accordingly based on the project requirements.
-        # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        resources:
+          requests:
+            memory: 32Mi
+            cpu: 10m
+          limits:
+            memory: 64Mi
+            cpu: 100m
       serviceAccountName: manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Define requested resources and limits so that k8s would use guaranteed qos service class

**Related issue(s)**
Fixes #173 