### PR TITLE
Do not save kyma-bot commits in the changelog

### DIFF
--- a/scripts/create_changelog.sh
+++ b/scripts/create_changelog.sh
@@ -25,7 +25,9 @@ echo "## What has changed" >> ${CHANGELOG_FILE}
 git log ${LATEST_RELEASE}..HEAD --pretty=tformat:"%h" --reverse | while read -r commit
 do
     COMMIT_AUTHOR=$(curl -H "${GITHUB_AUTH_HEADER}" -sS "${GITHUB_URL}/commits/${commit}" | jq -r '.author.login')
-    git show -s ${commit} --format="* %s by @${COMMIT_AUTHOR}" >> ${CHANGELOG_FILE}
+    if [ "${COMMIT_AUTHOR}" != "kyma-bot" ]; then
+      git show -s ${commit} --format="* %s by @${COMMIT_AUTHOR}" >> ${CHANGELOG_FILE}
+    fi
 done
 
 NEW_CONTRIB=$$.new


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Commits made by kyma-bot are no longer saved in changelog

**Related issue(s)**
https://github.com/kyma-project/keda-manager/issues/129