### PR TITLE
Bump golang-runtime to 1.20.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.4 as builder
+FROM golang:1.20.5 as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Use latest version of golang-runtime