### PR TITLE
Fix release tag checker

### DIFF
--- a/scripts/check_release_tag.sh
+++ b/scripts/check_release_tag.sh
@@ -5,6 +5,7 @@ set -e
 DESIRED_TAG=$1
 
 source .version
+MODULE_VERSION="v${MODULE_VERSION}"
 
 if [[ "$DESIRED_TAG" != "$MODULE_VERSION" ]]; then
   echo "Tags are not correct: wanted $DESIRED_TAG but got $MODULE_VERSION"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- check if release tag starts with  `v`

**Related issue(s)**
https://github.com/kyma-project/keda-manager/issues/227
