### PR TITLE
Check also the date in the image

### DIFF
--- a/scripts/check_image.sh
+++ b/scripts/check_image.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
-RAW_EXPECTED_HASH=$(git log main --author "Kyma Bot" --max-count 1 --skip 1 --format=format:%H)
-SHORT_EXPECTED_HASH=${RAW_EXPECTED_HASH:0:8}
+RAW_EXPECTED_TAG=$(git log main --author "Kyma Bot" --max-count 1 --skip 1 --format=format:%H)
+SHORT_EXPECTED_TAG=${RAW_EXPECTED_TAG:0:8}
 DATE="v$(git log main --author "Kyma Bot" --max-count 1 --skip 1 --format=format:%ad --date=format:'%Y%m%d')"
-EXPECTED_HASH="${DATE}-${SHORT_EXPECTED_HASH}"
+EXPECTED_TAG="${DATE}-${SHORT_EXPECTED_TAG}"
 
 IMAGE_TO_CHECK="${1:-europe-docker.pkg.dev/kyma-project/prod/keda-manager}"
-BUMPED_IMAGE_HASH=$(cat sec-scanners-config.yaml | grep "${IMAGE_TO_CHECK}" | cut -d : -f 2)
+BUMPED_IMAGE_TAG=$(cat sec-scanners-config.yaml | grep "${IMAGE_TO_CHECK}" | cut -d : -f 2)
 
-if [[ "$BUMPED_IMAGE_HASH" != "$EXPECTED_HASH" ]]; then
-  echo "Tags are not correct: wanted $EXPECTED_HASH but got $BUMPED_IMAGE_HASH"
+if [[ "$BUMPED_IMAGE_TAG" != "$EXPECTED_TAG" ]]; then
+  echo "Tags are not correct: wanted $EXPECTED_TAG but got $BUMPED_IMAGE_TAG"
   exit 1
 fi
 echo "Tags are correct"

--- a/scripts/check_image.sh
+++ b/scripts/check_image.sh
@@ -2,12 +2,14 @@
 
 RAW_EXPECTED_HASH=$(git log main --author "Kyma Bot" --max-count 1 --skip 1 --format=format:%H)
 SHORT_EXPECTED_HASH=${RAW_EXPECTED_HASH:0:8}
+DATE="v$(git log main --author "Kyma Bot" --max-count 1 --skip 1 --format=format:%ad --date=format:'%Y%m%d')"
+EXPECTED_HASH="${DATE}-${SHORT_EXPECTED_HASH}"
 
 IMAGE_TO_CHECK="${1:-europe-docker.pkg.dev/kyma-project/prod/keda-manager}"
-BUMPED_IMAGE_HASH=$(cat sec-scanners-config.yaml | grep "${IMAGE_TO_CHECK}" | cut -d : -f 2 | cut -d - -f 2)
+BUMPED_IMAGE_HASH=$(cat sec-scanners-config.yaml | grep "${IMAGE_TO_CHECK}" | cut -d : -f 2)
 
-if [[ "$BUMPED_IMAGE_HASH" != "$SHORT_EXPECTED_HASH" ]]; then
-  echo "Tags are not correct: wanted $SHORT_EXPECTED_HASH but got $BUMPED_IMAGE_HASH"
+if [[ "$BUMPED_IMAGE_HASH" != "$EXPECTED_HASH" ]]; then
+  echo "Tags are not correct: wanted $EXPECTED_HASH but got $BUMPED_IMAGE_HASH"
   exit 1
 fi
 echo "Tags are correct"


### PR DESCRIPTION


If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

check in `check_image.sh` also if the date is correct (besides of commit hash)

Changes proposed in this pull request:

- check in `check_image.sh` also if the date is correct (besides of commit hash)

**Related issue(s)**
https://github.com/kyma-project/keda-manager/issues/227
