### PR TITLE
Remove istio side-car from keda workloads

### DIFF
--- a/keda.yaml
+++ b/keda.yaml
@@ -9591,6 +9591,7 @@ spec:
         app.kubernetes.io/instance: keda
         app.kubernetes.io/part-of: keda-operator
         app.kubernetes.io/version: 2.11.1
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: keda-operator
       automountServiceAccountToken: true
@@ -9703,6 +9704,7 @@ spec:
         app.kubernetes.io/instance: keda
         app.kubernetes.io/part-of: keda-operator
         app.kubernetes.io/version: 2.11.1
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: keda-operator
       automountServiceAccountToken: true
@@ -9815,6 +9817,7 @@ spec:
         app.kubernetes.io/instance: keda
         app.kubernetes.io/part-of: keda-operator
         app.kubernetes.io/version: 2.11.1
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: keda-operator
       automountServiceAccountToken: true


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Keda workloads should not have istio carts injected. Bringing back the istio labels after keda 2.11.1 bump
 #237 