### PR TITLE
Adjust check sec-scanners in release

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -22,8 +22,8 @@ jobs:
       - name: Check tag
         run: ./scripts/check_release_tag.sh ${{ github.event.inputs.name }}
 
-#       - name: Check image
-#         run: ./scripts/check_image.sh
+      - name: Check image
+        run: ./scripts/check_image.sh
 
       - name: Verify
         run: ./scripts/verify-keda-status.sh

--- a/scripts/check_image.sh
+++ b/scripts/check_image.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-RAW_EXPECTED_TAG=$(git log main --author "Kyma Bot" --max-count 1 --skip 1 --format=format:%H)
+RAW_EXPECTED_TAG=$(git log main --max-count 1 --skip 1 --format=format:%H)
 SHORT_EXPECTED_TAG=${RAW_EXPECTED_TAG:0:8}
-DATE="v$(git log main --author "Kyma Bot" --max-count 1 --skip 1 --format=format:%ad --date=format:'%Y%m%d')"
+DATE="v$(git log main --max-count 1 --skip 1 --format=format:%ad --date=format:'%Y%m%d')"
 EXPECTED_TAG="${DATE}-${SHORT_EXPECTED_TAG}"
 
 IMAGE_TO_CHECK="${1:-europe-docker.pkg.dev/kyma-project/prod/keda-manager}"


### PR DESCRIPTION
**Description**

Due to lack of kyma-bot merge commit hash the `check_image.sh` need to be adjusted.

Changes proposed in this pull request:

- Get penultimate commit hash instead of penultimate kyma-bot's
