### PR TITLE
Skip DORA metrics step

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -72,7 +72,7 @@ jobs:
 
   publish-release:
     name: Publish release
-    needs: [verify-head-status, create-draft, run-unit-tests, devOps-Insights]
+    needs: [verify-head-status, create-draft, run-unit-tests]
     runs-on: ubuntu-latest
 
     steps:

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,6 +1,6 @@
 module-name: keda
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/keda-manager:v20230901-99573403
+  - europe-docker.pkg.dev/kyma-project/prod/keda-manager:v20230901-d846a967
   - europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/kedacore/keda:2.11.2
   - europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/kedacore/keda-admission-webhooks:2.11.2
   - europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/kedacore/keda-metrics-apiserver:2.11.2


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- temporarily skip publishing release metrics to DORA to unblosk create-release workflow

**Related issue(s)**
#272 