### PR TITLE
Bump Golang img version (1.21.0)

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: keda-manager 
-Upstream-Contact: 
+Upstream-Contact: krzysztof.kwiatosz@sap.com
 Source: https://github.com/kyma-project/keda-manager
 Disclaimer: The code in this project may include calls to APIs (“API Calls”) of
  SAP or third-party products or services developed outside of this project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.5 as builder
+FROM golang:1.21.0 as builder
 
 WORKDIR /workspace
 

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,6 +1,6 @@
 module-name: keda
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/keda-manager:v20230901-d846a967
+  - europe-docker.pkg.dev/kyma-project/prod/keda-manager:v20230904-20efc6aa
   - europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/kedacore/keda:2.11.2
   - europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/kedacore/keda-admission-webhooks:2.11.2
   - europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/kedacore/keda-metrics-apiserver:2.11.2


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use latest versin of golang in builder image
- Fill in upstream contact info
- bump sec scanner config

