### PR TITLE
Set Warning state when orphaned CRs found at deletion

### DIFF
--- a/api/v1alpha1/keda_types.go
+++ b/api/v1alpha1/keda_types.go
@@ -301,6 +301,18 @@ type Keda struct {
 }
 
 func (k *Keda) UpdateStateFromErr(c ConditionType, r ConditionReason, err error) {
+	k.Status.State = StateError
+	condition := metav1.Condition{
+		Type:               string(c),
+		Status:             "False",
+		LastTransitionTime: metav1.Now(),
+		Reason:             string(r),
+		Message:            err.Error(),
+	}
+	meta.SetStatusCondition(&k.Status.Conditions, condition)
+}
+
+func (k *Keda) UpdateStateFromWarning(c ConditionType, r ConditionReason, err error) {
 	k.Status.State = StateWarning
 	condition := metav1.Condition{
 		Type:               string(c),

--- a/api/v1alpha1/keda_types.go
+++ b/api/v1alpha1/keda_types.go
@@ -34,6 +34,7 @@ type ConditionType string
 const (
 	StateReady      = "Ready"
 	StateError      = "Error"
+	StateWarning    = "Warning"
 	StateProcessing = "Processing"
 	StateDeleting   = "Deleting"
 
@@ -300,7 +301,7 @@ type Keda struct {
 }
 
 func (k *Keda) UpdateStateFromErr(c ConditionType, r ConditionReason, err error) {
-	k.Status.State = StateError
+	k.Status.State = StateWarning
 	condition := metav1.Condition{
 		Type:               string(c),
 		Status:             "False",

--- a/pkg/reconciler/delete_resources.go
+++ b/pkg/reconciler/delete_resources.go
@@ -81,7 +81,7 @@ func sFnUpstreamDeletionState(ctx context.Context, r *fsm, s *systemState) (stat
 
 func sFnSafeDeletionState(ctx context.Context, r *fsm, s *systemState) (stateFn, *ctrl.Result, error) {
 	if err := checkCRDOrphanResources(ctx, r); err != nil {
-		s.instance.UpdateStateFromErr(v1alpha1.ConditionTypeDeleted, v1alpha1.ConditionReasonDeletionErr, err)
+		s.instance.UpdateStateFromWarning(v1alpha1.ConditionTypeDeleted, v1alpha1.ConditionReasonDeletionErr, err)
 		return stopWithErrorAndNoRequeue(err)
 	}
 

--- a/pkg/reconciler/delete_resources_test.go
+++ b/pkg/reconciler/delete_resources_test.go
@@ -328,7 +328,7 @@ func Test_sFnDeleteStrategy(t *testing.T) {
 			fn,
 		)
 
-		require.Equal(t, v1alpha1.StateError, s.instance.Status.State)
+		require.Equal(t, v1alpha1.StateWarning, s.instance.Status.State)
 		conditionDeleted := meta.FindStatusCondition(s.instance.Status.Conditions, string(v1alpha1.ConditionTypeDeleted))
 		require.NotNil(t, conditionDeleted)
 		require.Equal(t, string(v1alpha1.ConditionReasonDeletionErr), conditionDeleted.Reason)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

When user intervention is needed, status of the module should be set to Warning.

**Related issue(s)**
https://github.com/kyma-project/serverless-manager/issues/259
https://github.com/kyma-project/lifecycle-manager/issues/525