### PR TITLE
Align keda's labels with current standard 

### DIFF
--- a/pkg/reconciler/fsm.go
+++ b/pkg/reconciler/fsm.go
@@ -84,8 +84,11 @@ func updateDeploymentContainer0Args(deployment appsv1.Deployment, updater api.Ar
 	return nil
 }
 
-func updateDeploymentSidecarInjection(deployment *appsv1.Deployment, config sidecarConfig) error {
+func updateDeploymentLabels(deployment *appsv1.Deployment, config sidecarConfig) error {
 	deployment.Spec.Template.ObjectMeta.Labels["sidecar.istio.io/inject"] = strconv.FormatBool(config.inject)
+	deployment.Spec.Template.ObjectMeta.Labels["kyma-project.io/module"] = "keda-manager"
+	deployment.Spec.Template.ObjectMeta.Labels["app.kubernetes.io/part-of"] = "keda-manager"
+	deployment.Spec.Template.ObjectMeta.Labels["app.kubernetes.io/managed-by"] = ""
 	return nil
 }
 

--- a/pkg/reconciler/update_objects.go
+++ b/pkg/reconciler/update_objects.go
@@ -38,7 +38,7 @@ func buildSfnUpdateOperatorLogging(u *unstructured.Unstructured) stateFn {
 
 func buildSfnUpdateOperatorLabels(u *unstructured.Unstructured) stateFn {
 	next := buildSfnUpdateOperatorPriorityClass(u)
-	return buildSfnUpdateObject(u, updateDeploymentSidecarInjection, sidecarInjectionConfig, next)
+	return buildSfnUpdateObject(u, updateDeploymentLabels, sidecarInjectionConfig, next)
 }
 
 func buildSfnUpdateOperatorPriorityClass(u *unstructured.Unstructured) stateFn {
@@ -76,7 +76,7 @@ func buildSfnUpdateMetricsSvrLogging(u *unstructured.Unstructured) stateFn {
 
 func buildSfnUpdateMetricsSvrLabels(u *unstructured.Unstructured) stateFn {
 	next := buildSfnUpdateMetricsSvrPriorityClass(u)
-	return buildSfnUpdateObject(u, updateDeploymentSidecarInjection, sidecarInjectionConfig, next)
+	return buildSfnUpdateObject(u, updateDeploymentLabels, sidecarInjectionConfig, next)
 }
 
 func buildSfnUpdateMetricsSvrPriorityClass(u *unstructured.Unstructured) stateFn {
@@ -109,7 +109,7 @@ func sFnUpdateAdmissionWebhooksDeployment(_ context.Context, r *fsm, s *systemSt
 
 func buildSfnUpdateAdmissionWebhooksLabels(u *unstructured.Unstructured) stateFn {
 	next := buildSfnUpdateAdmissionWebhooksPriorityClass(u)
-	return buildSfnUpdateObject(u, updateDeploymentSidecarInjection, sidecarInjectionConfig, next)
+	return buildSfnUpdateObject(u, updateDeploymentLabels, sidecarInjectionConfig, next)
 }
 func buildSfnUpdateAdmissionWebhooksPriorityClass(u *unstructured.Unstructured) stateFn {
 	return buildSfnUpdateObject(u, updateDeploymentPriorityClass, priorityClassName, sFnApply)


### PR DESCRIPTION
**Description**
Updated labels as such:
``` yaml
kyma-project.io/module: keda-manager 
app.kubernetes.io/name: keda-operator
app.kubernetes.io/instance: keda
app.kubernetes.io/version: 1.2.1
app.kubernetes.io/component: operato
app.kubernetes.io/part-of: keda-manager
app.kubernetes.io/managed-by: 
```
**Related issue(s)**
https://github.com/kyma-project/keda-manager/issues/457