### PR TITLE
Tests and bump k8s from 1.29 to 1.30

### DIFF
--- a/.github/actions/create-k3d-cluster/action.yaml
+++ b/.github/actions/create-k3d-cluster/action.yaml
@@ -10,7 +10,7 @@ runs:
         cluster-name: "k3dCluster"
         args: >-
           --agents 1
-          --image rancher/k3s:v1.29.3-k3s1
+          --image rancher/k3s:v1.30.0-k3s1
           --port 80:80@loadbalancer
           --port 443:443@loadbalancer
           --wait


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

Upgrading k8s in tests due to planned K8s Upgrade (from v.1.29 to v.1.30) in managed kyma runtime



**Related issue(s)**
https://github.com/kyma-project/keda-manager/pull/421
