### PR TITLE
Restore Min TLS 1.2 as default

### DIFF
--- a/api/v1alpha1/keda_types.go
+++ b/api/v1alpha1/keda_types.go
@@ -264,7 +264,7 @@ var (
 	}
 	kedaHTTPMinTLSVersion = corev1.EnvVar{
 		Name:  "KEDA_HTTP_MIN_TLS_VERSION",
-		Value: "TLS13",
+		Value: "TLS12",
 	}
 )
 

--- a/docs/user/01-20-configuration.md
+++ b/docs/user/01-20-configuration.md
@@ -74,13 +74,13 @@ See how to configure the **logging.level** attribute or the resource consumption
    
    ```
 
-- To override the minimum TLS version used by Keda (default is `TLS13`), set the `KEDA_HTTP_MIN_TLS_VERSION` environment variable. For example:
+- To override the minimum TLS version used by Keda (default is `TLS12`), set the `KEDA_HTTP_MIN_TLS_VERSION` environment variable. For example:
 
    ```yaml
    spec:
      env:
        - name: KEDA_HTTP_MIN_TLS_VERSION
-         value: TLS12
+         value: TLS13
    ```
 
 For more information about the Keda resources, see [Keda concepts](https://keda.sh/docs/latest/concepts/).

--- a/hack/keda_values.yaml
+++ b/hack/keda_values.yaml
@@ -14,7 +14,7 @@ prometheus:
     enabled: true
 
 http:
-  minTlsVersion: TLS13
+  minTlsVersion: TLS12
 
 image:
   pullPolicy: IfNotPresent

--- a/keda.yaml
+++ b/keda.yaml
@@ -11227,7 +11227,7 @@ spec:
             - name: KEDA_HTTP_DEFAULT_TIMEOUT
               value: "3000"
             - name: KEDA_HTTP_MIN_TLS_VERSION
-              value: TLS13
+              value: TLS12
           volumeMounts:         
           - mountPath: /certs
             name: certificates
@@ -11331,7 +11331,7 @@ spec:
             - name: KEDA_HTTP_DEFAULT_TIMEOUT
               value: "3000"
             - name: KEDA_HTTP_MIN_TLS_VERSION
-              value: TLS13
+              value: TLS12
           command:
            - /keda-adapter
           args:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Enforcing min TLS 1.3 causes disruptions for already defined scalers relying on TLS1.2

