### PR TITLE
Remove build-engine: buildx

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -39,4 +39,3 @@ jobs:
       name: keda-manager
       dockerfile: Dockerfile
       tags: ${{ needs.compute-tags.outputs.tags }}
-      build-engine: buildx


### PR DESCRIPTION
This PR removes the deprecated `build-engine: buildx` entry from workflows.