### PR TITLE
Use GH BOT token for tagging

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -53,6 +53,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.BOT_TOKEN }}
           fetch-depth: 0
           ref: ${{ github.ref_name }}  # Checkout to latest branch changes
       - name: Create tag


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix 403 in release pipeline for tagging step

**Related issue(s)**
#662 