### PR TITLE
Fix trigger types rendering in busola

### DIFF
--- a/config/ui-extensions/scaledobjects/list
+++ b/config/ui-extensions/scaledobjects/list
@@ -2,7 +2,6 @@
   source: $join([spec.scaleTargetRef.name, ' (', spec.scaleTargetRef.kind?spec.scaleTargetRef.kind:"Deployment", ')'])
 - name: Triggers
   source: status.triggersTypes
-  widget: JoinedArray
 - name: Replicas
   source: $join([$string(spec.minReplicaCount), '..', $string(spec.maxReplicaCount)])
 - name: Ready


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fixes list widget config after Keda's `ScaledObject` API change of the `status`

<img width="1154" height="297" alt="Screenshot 2025-09-12 at 13 57 23" src="https://github.com/user-attachments/assets/d96b2875-fabe-492f-83e3-9acdd931301c" />

The listed attribute is no longer an array

```
status:
     triggersTypes: cpu,dynatrace
```
**Related issue(s)**
#681 
