### PR TITLE
Take care about the non-served Keda CR even after second CR was removed

### DIFF
--- a/pkg/reconciler/served_filter.go
+++ b/pkg/reconciler/served_filter.go
@@ -3,14 +3,14 @@ package reconciler
 import (
 	"context"
 	"fmt"
+
 	"github.com/kyma-project/keda-manager/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func sFnServedFilter(ctx context.Context, r *fsm, s *systemState) (stateFn, *ctrl.Result, error) {
-	if s.instance.IsServedEmpty() {
-
+	if s.instance.IsServedEmpty() || s.instance.Status.Served == v1alpha1.ServedFalse {
 		// keda CRs check
 		servedKeda, err := findServedKeda(ctx, r.Client)
 		if err != nil {
@@ -26,10 +26,6 @@ func sFnServedFilter(ctx context.Context, r *fsm, s *systemState) (stateFn, *ctr
 		}
 
 		return stopWithRequeue()
-	}
-
-	if s.instance.Status.Served == v1alpha1.ServedFalse {
-		return nil, nil, nil
 	}
 
 	return switchState(sFnTakeSnapshot)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- requeue all Keda CRs after one of them is removed (to recalculated the `.status.served` field)
- recalculate the `.status.served` field on every reconciliation to give all resources a "second chance" 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/issues/1963