### PR TITLE
Ensure keda-manger runs w/o istio sidecar

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        sidecar.istio.io/inject: "false"
       labels:
         app.kubernetes.io/component: keda-manager.kyma-project.io
         control-plane: manager


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Override instio-injection configuration on namespace level by enforcing no injection on manager deployment level

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
