### PR TITLE
Allow all egress traffic for the keda-operator and the keda-operator-apiserver-metrics

### DIFF
--- a/keda-networkpolicies.yaml
+++ b/keda-networkpolicies.yaml
@@ -157,7 +157,8 @@ spec:
 # NetworkPolicies for the KEDA operator
 ##
 
-# NetworkPolicy to allow egress traffic from keda-operator to k8s API server
+# NetworkPolicy to allow whole egress traffic
+# this is needed to allow the operator to communicate with any service to scrape metrics for scaling purposes
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -171,8 +172,8 @@ metadata:
     app.kubernetes.io/part-of: keda-operator
     app.kubernetes.io/version: 2.18.1
     app.kubernetes.io/instance: keda
-    purpose: allow-to-apiserver
-  name: kyma-project.io--keda-operator-allow-to-apiserver
+    purpose: allow-to-all
+  name: kyma-project.io--keda-operator-allow-to-all
   namespace: kyma-system
 spec:
   podSelector:
@@ -181,68 +182,7 @@ spec:
   policyTypes:
   - Egress
   egress:
-  - ports:
-    - port: 443
-      protocol: TCP
-    - port: 6443
-      protocol: TCP
----
-# NetworkPolicy to allow egress traffic from keda-operator to DNS
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    app: keda-operator
-    name: keda-operator
-    app.kubernetes.io/name: keda-operator    
-    helm.sh/chart: keda-2.18.1
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: keda-operator
-    app.kubernetes.io/version: 2.18.1
-    app.kubernetes.io/instance: keda
-    purpose: allow-to-dns
-  name: kyma-project.io--keda-operator-allow-to-dns
-  namespace: kyma-system
-spec:
-  podSelector:
-    matchLabels:
-      app: keda-operator
-  policyTypes:
-  - Egress
-  egress:
-    - ports:
-        - port: 53
-          protocol: UDP
-        - port: 53
-          protocol: TCP
-      to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-    - ports:
-        - port: 8053
-          protocol: UDP
-        - port: 8053
-          protocol: TCP
-      to:
-        - namespaceSelector:
-            matchLabels:
-              gardener.cloud/purpose: kube-system
-          podSelector:
-            matchLabels:
-              k8s-app: kube-dns
-    - ports:
-        - port: 53
-          protocol: UDP
-        - port: 53
-          protocol: TCP
-      to:
-        - namespaceSelector:
-            matchLabels:
-              gardener.cloud/purpose: kube-system
-          podSelector:
-            matchLabels:
-              k8s-app: node-local-dns
+  - {}
 ---
 # NetworkPolicy to allow keda-operator-metrics-apiserver to communicate with keda-operator
 apiVersion: networking.k8s.io/v1
@@ -313,7 +253,8 @@ spec:
 # NetworkPolicies for the KEDA metrics apiserver
 ##
 
-# NetworkPolicy to allow egress traffic from keda-operator-metrics-apiserver to k8s API server
+# NetworkPolicy to allow whole egress traffic
+# this is needed to allow the operator to communicate with any service to scrape metrics for scaling purposes
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -326,8 +267,8 @@ metadata:
     app.kubernetes.io/part-of: keda-operator
     app.kubernetes.io/version: 2.18.1
     app.kubernetes.io/instance: keda
-    purpose: allow-to-apiserver
-  name: kyma-project.io--keda-operator-metrics-apiserver-allow-to-apiserver
+    purpose: allow-to-all
+  name: kyma-project.io--keda-operator-metrics-apiserver-allow-to-all
   namespace: kyma-system
 spec:
   podSelector:
@@ -336,67 +277,7 @@ spec:
   policyTypes:
   - Egress
   egress:
-  - ports:
-    - port: 443
-      protocol: TCP
-    - port: 6443
-      protocol: TCP
----
-# NetworkPolicy to allow egress traffic from keda-operator-metrics-apiserver to DNS
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    app: keda-operator-metrics-apiserver
-    app.kubernetes.io/name: keda-operator-metrics-apiserver    
-    helm.sh/chart: keda-2.18.1
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: keda-operator
-    app.kubernetes.io/version: 2.18.1
-    app.kubernetes.io/instance: keda
-    purpose: allow-to-dns
-  name: kyma-project.io--keda-operator-metrics-apiserver-allow-to-dns
-  namespace: kyma-system
-spec:
-  podSelector:
-    matchLabels:
-      app: keda-operator-metrics-apiserver
-  policyTypes:
-  - Egress
-  egress:
-    - ports:
-        - port: 53
-          protocol: UDP
-        - port: 53
-          protocol: TCP
-      to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-    - ports:
-        - port: 8053
-          protocol: UDP
-        - port: 8053
-          protocol: TCP
-      to:
-        - namespaceSelector:
-            matchLabels:
-              gardener.cloud/purpose: kube-system
-          podSelector:
-            matchLabels:
-              k8s-app: kube-dns
-    - ports:
-        - port: 53
-          protocol: UDP
-        - port: 53
-          protocol: TCP
-      to:
-        - namespaceSelector:
-            matchLabels:
-              gardener.cloud/purpose: kube-system
-          podSelector:
-            matchLabels:
-              k8s-app: node-local-dns
+  - {}
 ---
 # NetworkPolicy to allow scraping metrics from keda-operator-metrics-apiserver
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- keda module can call any service to get metrics for scaling purposes - it's not possible to define a list of such services and the only way to run a fully featured keda module is to allow it to call any service

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/keda-manager/issues/724