### PR TITLE
Allow K8s ApiServer to reach Keda's Metric API Server endpoint

### DIFF
--- a/keda-networkpolicies.yaml
+++ b/keda-networkpolicies.yaml
@@ -340,3 +340,29 @@ spec:
     - podSelector:
         matchLabels:
           app: keda-operator
+---
+# NetworkPolicy to allow scraping hpa oriented metrics from keda-operator-metrics-apiserver
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: keda-operator-metrics-apiserver
+    app.kubernetes.io/name: keda-operator-metrics-apiserver    
+    helm.sh/chart: keda-2.18.1
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.18.1
+    app.kubernetes.io/instance: keda
+    purpose: ingress-all-from-apiserver
+  name: kyma-project.io--keda-operator-metrics-apiserver-ingress-all-from-apiserver
+  namespace: kyma-system
+spec:
+  podSelector:
+    matchLabels:
+      app: keda-operator-metrics-apiserver
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+      - port: 6443

--- a/pkg/reconciler/fsm.go
+++ b/pkg/reconciler/fsm.go
@@ -103,6 +103,20 @@ func setCommonLabels(labels map[string]string) map[string]string {
 	return labels
 }
 
+// update NetworkPolicy to allow scraping metrics from k8s apiserver IP
+func updateMetricsServerIngressNetworkPolicy(np *networkingv1.NetworkPolicy, apiServerAddress string) error {
+	for i := range np.Spec.Ingress {
+		np.Spec.Ingress[i].From = []networkingv1.NetworkPolicyPeer{
+			{
+				IPBlock: &networkingv1.IPBlock{
+					CIDR: apiServerAddress,
+				},
+			},
+		}
+	}
+	return nil
+}
+
 func updateAdmissionWebhooksNetworkPolicy(np *networkingv1.NetworkPolicy, apiServerAddress string) error {
 	for i := range np.Spec.Ingress {
 		in := &np.Spec.Ingress[i]
@@ -187,6 +201,11 @@ var (
 			u.GetAPIVersion() == "networking.k8s.io/v1" &&
 			u.GetLabels()["purpose"] == "webhook"
 	}
+	ifMetricServerNetworkPolicy predicate = func(u unstructured.Unstructured) bool {
+		return u.GetKind() == "NetworkPolicy" &&
+			u.GetAPIVersion() == "networking.k8s.io/v1" &&
+			u.GetLabels()["purpose"] == "ingress-all-from-apiserver"
+	}
 	isKedaOperatorDeployment predicate = func(u unstructured.Unstructured) bool {
 		return hasOperatorName(u) && isDeployment(u)
 	}
@@ -204,6 +223,9 @@ var (
 	}
 	isAddmissionWebhookNetworkPolicy predicate = func(u unstructured.Unstructured) bool {
 		return isWebhookNetworkPolicy(u)
+	}
+	isMetricServerIngressNetworkPolicy predicate = func(u unstructured.Unstructured) bool {
+		return ifMetricServerNetworkPolicy(u)
 	}
 )
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- allow k8s to access Keda's Metrics API server on port 6443

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/keda-manager/issues/744