### PR TITLE
Cherry-pick: Keep metrics apiserver http endpoint open to all inside a cluster

### DIFF
--- a/pkg/reconciler/fsm.go
+++ b/pkg/reconciler/fsm.go
@@ -103,20 +103,6 @@ func setCommonLabels(labels map[string]string) map[string]string {
 	return labels
 }
 
-// update NetworkPolicy to allow scraping metrics from k8s apiserver IP
-func updateMetricsServerIngressNetworkPolicy(np *networkingv1.NetworkPolicy, apiServerAddress string) error {
-	for i := range np.Spec.Ingress {
-		np.Spec.Ingress[i].From = []networkingv1.NetworkPolicyPeer{
-			{
-				IPBlock: &networkingv1.IPBlock{
-					CIDR: apiServerAddress,
-				},
-			},
-		}
-	}
-	return nil
-}
-
 func updateAdmissionWebhooksNetworkPolicy(np *networkingv1.NetworkPolicy, apiServerAddress string) error {
 	for i := range np.Spec.Ingress {
 		in := &np.Spec.Ingress[i]
@@ -201,11 +187,6 @@ var (
 			u.GetAPIVersion() == "networking.k8s.io/v1" &&
 			u.GetLabels()["purpose"] == "webhook"
 	}
-	ifMetricServerNetworkPolicy predicate = func(u unstructured.Unstructured) bool {
-		return u.GetKind() == "NetworkPolicy" &&
-			u.GetAPIVersion() == "networking.k8s.io/v1" &&
-			u.GetLabels()["purpose"] == "ingress-all-from-apiserver"
-	}
 	isKedaOperatorDeployment predicate = func(u unstructured.Unstructured) bool {
 		return hasOperatorName(u) && isDeployment(u)
 	}
@@ -223,9 +204,6 @@ var (
 	}
 	isAddmissionWebhookNetworkPolicy predicate = func(u unstructured.Unstructured) bool {
 		return isWebhookNetworkPolicy(u)
-	}
-	isMetricServerIngressNetworkPolicy predicate = func(u unstructured.Unstructured) bool {
-		return ifMetricServerNetworkPolicy(u)
 	}
 )
 

--- a/pkg/reconciler/update_objects.go
+++ b/pkg/reconciler/update_objects.go
@@ -130,25 +130,7 @@ func buildSfnUpdateMetricsSvrResources(u *unstructured.Unstructured) stateFn {
 }
 
 func buildSfnUpdateMetricsSvrEnvVars(u *unstructured.Unstructured) stateFn {
-	return buildSfnUpdateObject(u, updateKedaContanierEnvs, envVars, buildSfnUpdateMetricsSvrNetworkPolicy)
-}
-
-func buildSfnUpdateMetricsSvrNetworkPolicy(ctx context.Context, f *fsm, ss *systemState) (stateFn, *ctrl.Result, error) {
-	np, err := f.firstUnstructed(isMetricServerIngressNetworkPolicy)
-	if err != nil {
-		ss.instance.UpdateStateFromErr(
-			v1alpha1.ConditionTypeInstalled,
-			v1alpha1.ConditionReasonNetworkPolicyUpdateErr,
-			err,
-		)
-		return stopWithErrorAndNoRequeue(err)
-	}
-
-	ipBlock := fmt.Sprintf("%s/32", f.APIServerIP)
-
-	return switchState(
-		buildSfnUpdateObject(np, updateMetricsServerIngressNetworkPolicy, networkPolicyAPIServerAddress(ipBlock), sFnUpdateAdmissionWebhooksDeployment),
-	)
+	return buildSfnUpdateObject(u, updateKedaContanierEnvs, envVars, sFnUpdateAdmissionWebhooksDeployment)
 }
 
 func sFnUpdateAdmissionWebhooksDeployment(_ context.Context, r *fsm, s *systemState) (stateFn, *ctrl.Result, error) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- cherry-pick: https://github.com/kyma-project/keda-manager/pull/747

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/keda-manager/issues/744