### PR TITLE
Auto-exclude metricserver port when proxied by istio

### DIFF
--- a/pkg/reconciler/update_objects.go
+++ b/pkg/reconciler/update_objects.go
@@ -47,10 +47,18 @@ func podAnnotationsOperatorCfg(k *v1alpha1.Keda) *map[string]string {
 }
 
 func podAnnotationsMetricsServerCfg(k *v1alpha1.Keda) *map[string]string {
-	if k != nil && k.Spec.PodAnnotations != nil {
-		return &k.Spec.PodAnnotations.MetricsServer
+	annotations := make(map[string]string)
+	if k.Spec.Istio != nil && k.Spec.Istio.MetricServer != nil && k.Spec.Istio.MetricServer.EnabledSidecarInjection {
+		// Add metric server port to istio excluded inbound ports
+		annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = "6443"
 	}
-	return nil
+	if k != nil && k.Spec.PodAnnotations != nil {
+		// Add user defined annotations
+		for key, value := range k.Spec.PodAnnotations.MetricsServer {
+			annotations[key] = value
+		}
+	}
+	return &annotations
 }
 
 func podAnnotationsAdmissionWebhookCfg(k *v1alpha1.Keda) *map[string]string {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Automatically adds istio exclusion annotation for the metric server workload to make it ALWAYS reachable by k8s also in istio scenarios

**Related issue(s)**
#753 