### PR TITLE
Increase memory limit for keda-manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,7 +74,7 @@ spec:
               memory: 32Mi
               cpu: 10m
             limits:
-              memory: 128Mi
+              memory: 512Mi
               cpu: 200m
       volumes:
         - name: config


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- increasing memory limit to accommodate the caching needs on clusters with large volumes of resources of the same type that keda-manager is watching 

**Related issue(s)**
https://github.tools.sap/kyma/backlog/issues/8562