### PR TITLE
Remove unnecessary wildcards from ClusterRoles

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,17 +9,11 @@ rules:
   resources:
   - configmaps
   - configmaps/status
-  - events
-  - services
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
   - external
   - pods
   - secrets
   - serviceaccounts
+  - services
   verbs:
   - create
   - delete
@@ -27,6 +21,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -52,7 +53,11 @@ rules:
   resources:
   - '*/scale'
   verbs:
-  - '*'
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
@@ -122,19 +127,34 @@ rules:
   resources:
   - horizontalpodautoscalers
   verbs:
-  - '*'
+  - create
+  - delete
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - batch
   resources:
   - jobs
   verbs:
-  - '*'
+  - create
+  - delete
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - coordination.k8s.io
   resources:
   - leases
   verbs:
-  - '*'
+  - create
+  - delete
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - discovery.k8s.io
   resources:
@@ -150,13 +170,17 @@ rules:
   - clustercloudeventsources
   - clustercloudeventsources/status
   verbs:
-  - '*'
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - external.metrics.k8s.io
   resources:
-  - '*'
+  - externalmetrics
   verbs:
-  - '*'
+  - list
+  - watch
 - apiGroups:
   - keda.sh
   resources:
@@ -171,7 +195,12 @@ rules:
   - triggerauthentications
   - triggerauthentications/status
   verbs:
-  - '*'
+  - create
+  - delete
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/controllers/keda_controller_rbacs.go
+++ b/controllers/keda_controller_rbacs.go
@@ -1,30 +1,57 @@
 package controllers
 
-//+kubebuilder:rbac:groups="*",resources="*",verbs=get
-//+kubebuilder:rbac:groups=external.metrics.k8s.io,resources="*",verbs="*"
-//+kubebuilder:rbac:groups="",resources=configmaps;configmaps/status;events;services,verbs="*"
-//+kubebuilder:rbac:groups="",resources=external;pods;secrets;serviceaccounts,verbs=list;watch;create;delete;update;patch
+// Core API group permissions
+//+kubebuilder:rbac:groups="",resources=configmaps;configmaps/status,verbs=create;delete;list;patch;update;watch
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups="",resources=services,verbs=create;delete;list;patch;update;watch
+//+kubebuilder:rbac:groups="",resources=external;pods;secrets;serviceaccounts,verbs=create;delete;list;patch;update;watch
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=create;delete
 //+kubebuilder:rbac:groups="",resources=limitranges,verbs=list;watch
-//+kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=create;delete;update;patch;watch;list
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;clusterroles;rolebindings;roles,verbs=create;delete;update;patch;watch;list
+
+// API registration and extensions
+//+kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=create;delete;list;patch;update;watch
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;clusterroles;rolebindings;roles,verbs=create;delete;list;patch;update;watch
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=create;delete;update;patch;watch;list
-//+kubebuilder:rbac:groups="*",resources="*/scale",verbs="*"
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=list;watch;create;delete;update;patch
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=create;delete;list;patch;update;watch
+
+// REQUIRED WILDCARD PERMISSIONS FOR KEDA FUNCTIONALITY:
+// The following wildcard permissions are required because KEDA operator needs to:
+// 1. Scale any scalable resource (Deployments, StatefulSets, custom resources, CRDs with /scale subresource)
+// 2. Read various resources to gather metrics for scaling decisions (e.g., Prometheus, external metrics, custom resources)
+// These permissions are delegated to the keda-operator ClusterRole which KEDA uses at runtime.
+// Without these wildcards, KEDA would not be able to scale custom resources or read metrics from arbitrary sources.
+//+kubebuilder:rbac:groups="*",resources="*/scale",verbs=get;list;patch;update;watch
+//+kubebuilder:rbac:groups="*",resources="*",verbs=get
+
+// Apps API group
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;delete;list;patch;update;watch
 //+kubebuilder:rbac:groups=apps,resources=statefulsets;replicasets,verbs=list;watch
-//+kubebuilder:rbac:groups=batch,resources=jobs,verbs="*"
-//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs="*"
-//+kubebuilder:rbac:groups="keda.sh",resources=clustertriggerauthentications;clustertriggerauthentications/status;scaledjobs;scaledjobs/finalizers;scaledjobs/status;scaledobjects;scaledobjects/finalizers;scaledobjects/status;triggerauthentications;triggerauthentications/status,verbs="*"
-//+kubebuilder:rbac:groups="eventing.keda.sh",resources=cloudeventsources;cloudeventsources/status;clustercloudeventsources;clustercloudeventsources/status,verbs="*"
+
+// Batch API group
+//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;delete;list;patch;update;watch
+
+// Coordination API group
+//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create;delete;list;patch;update;watch
+
+// KEDA resources
+//+kubebuilder:rbac:groups="keda.sh",resources=clustertriggerauthentications;clustertriggerauthentications/status;scaledjobs;scaledjobs/finalizers;scaledjobs/status;scaledobjects;scaledobjects/finalizers;scaledobjects/status;triggerauthentications;triggerauthentications/status,verbs=create;delete;list;patch;update;watch
+//+kubebuilder:rbac:groups="eventing.keda.sh",resources=cloudeventsources;cloudeventsources/status;clustercloudeventsources;clustercloudeventsources/status,verbs=list;patch;update;watch
 //+kubebuilder:rbac:groups="discovery.k8s.io",resources="endpointslices",verbs=list;watch
 
-//+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs="*"
-//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=create;list;patch;update;watch;delete
+// External metrics API
+//+kubebuilder:rbac:groups=external.metrics.k8s.io,resources=externalmetrics,verbs=list;watch
 
-//+kubebuilder:rbac:groups=operator.kyma-project.io,resources=kedas,verbs=list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=operator.kyma-project.io,resources=kedas/status,verbs=update;patch
-//+kubebuilder:rbac:groups=operator.kyma-project.io,resources=kedas/finalizers,verbs=update;patch
+// Autoscaling
+//+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=create;delete;list;patch;update;watch
 
+// Webhooks
+//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=create;delete;list;patch;update;watch
+
+// Kyma Keda operator resources
+//+kubebuilder:rbac:groups=operator.kyma-project.io,resources=kedas,verbs=create;delete;list;patch;update;watch
+//+kubebuilder:rbac:groups=operator.kyma-project.io,resources=kedas/status,verbs=patch;update
+//+kubebuilder:rbac:groups=operator.kyma-project.io,resources=kedas/finalizers,verbs=patch;update
+
+// Network policies
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;list;patch;update;watch


### PR DESCRIPTION
This commit addresses issue #742 by:
1. Removing all verbs="*" wildcards and replacing with explicit verbs
2. Removing redundant RBAC rules covered by wildcard permissions
3. Keeping only 2 required wildcards with documentation:
   - groups="*",resources="*/scale" - Required for KEDA to scale any scalable resource
   - groups="*",resources="*",verbs=get - Required for KEDA to read resources for metrics The wildcards are documented and justified as they are essential for KEDA's core functionality of scaling arbitrary resources and reading metrics from various sources.
Fixes: https://github.com/kyma-project/keda-manager/issues/742