### PR TITLE
Pass PR SHA to check-fips-image-versions workflow for correct checkout

### DIFF
--- a/.github/workflows/_check-fips-image-versions.yaml
+++ b/.github/workflows/_check-fips-image-versions.yaml
@@ -2,12 +2,18 @@ name: check-fips-image-versions
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
 
 jobs:
   check-fips-image-versions:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
       - name: Check FIPS and non-FIPS Keda image versions are in sync
         run: |
           set -e

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -18,6 +18,8 @@ jobs:
 
   check-fips-image-versions:
     uses: kyma-project/keda-manager/.github/workflows/_check-fips-image-versions.yaml@main
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
 
   builds:
     uses: kyma-project/keda-manager/.github/workflows/_build.yaml@main


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Pass PR head SHA to check-fips-image-versions workflow for correct checkout

**Related issue(s)**
See also:
- #829 