### PR TITLE
Fix BTP e2e tests even though deny-all policies are not permitted

### DIFF
--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -31,7 +31,6 @@ remove-keda: ## Remove Keda CR
 .PHONY: run-on-cluster
 run-on-cluster:
 	@make -C ${PROJECT_COMMON} create-kyma-system-ns
-	@kubectl apply -f ${PROJECT_ROOT}/hack/deny-all-networkpolicy.yaml
 	@make -C ${PROJECT_COMMON} run-on-cluster
 
 .PHONY: install-latest


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Deny-all policies are blocked by admission policies on managed clusters