### PR TITLE
Normalize to JSON, skip empty YAML 

### DIFF
--- a/pkg/yaml/utils.go
+++ b/pkg/yaml/utils.go
@@ -1,11 +1,27 @@
 package yaml
 
 import (
+	"encoding/json"
 	"io"
 
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+// normalizeToJSON round-trips a value through JSON encoding/decoding so that
+// all numeric types become float64 (JSON-compatible), avoiding panics in
+// k8s.io/apimachinery's DeepCopyJSONValue which does not handle Go int.
+func normalizeToJSON(v map[string]interface{}) (map[string]interface{}, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
 
 func LoadData(r io.Reader) ([]unstructured.Unstructured, error) {
 	results := make([]unstructured.Unstructured, 0)
@@ -19,6 +35,18 @@ func LoadData(r io.Reader) ([]unstructured.Unstructured, error) {
 			break
 		}
 
+		if err != nil {
+			return nil, err
+		}
+
+		// Skip empty documents (e.g. blank --- separators in multi-doc YAML).
+		if len(obj) == 0 {
+			continue
+		}
+
+		// Normalize numeric types to JSON-compatible float64 to avoid panics
+		// in k8s.io/apimachinery's DeepCopyJSONValue (which doesn't handle int).
+		obj, err = normalizeToJSON(obj)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/yaml/utils_test.go
+++ b/pkg/yaml/utils_test.go
@@ -1,0 +1,105 @@
+package yaml
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadData(t *testing.T) {
+	t.Run("parses single document", func(t *testing.T) {
+		input := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm
+  namespace: default
+`
+		objs, err := LoadData(strings.NewReader(input))
+		require.NoError(t, err)
+		require.Len(t, objs, 1)
+		require.Equal(t, "ConfigMap", objs[0].GetKind())
+		require.Equal(t, "test-cm", objs[0].GetName())
+	})
+
+	t.Run("parses multi-document YAML", func(t *testing.T) {
+		input := `apiVersion: v1
+kind: Service
+metadata:
+  name: svc1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc2
+`
+		objs, err := LoadData(strings.NewReader(input))
+		require.NoError(t, err)
+		require.Len(t, objs, 2)
+		require.Equal(t, "svc1", objs[0].GetName())
+		require.Equal(t, "svc2", objs[1].GetName())
+	})
+
+	t.Run("CRDs are prepended", func(t *testing.T) {
+		input := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.example.com
+`
+		objs, err := LoadData(strings.NewReader(input))
+		require.NoError(t, err)
+		require.Len(t, objs, 2)
+		require.Equal(t, "CustomResourceDefinition", objs[0].GetKind())
+		require.Equal(t, "Deployment", objs[1].GetKind())
+	})
+
+	t.Run("skips empty documents", func(t *testing.T) {
+		input := `---
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+---
+`
+		objs, err := LoadData(strings.NewReader(input))
+		require.NoError(t, err)
+		require.Len(t, objs, 1)
+	})
+
+	t.Run("empty input returns empty slice", func(t *testing.T) {
+		objs, err := LoadData(strings.NewReader(""))
+		require.NoError(t, err)
+		require.Empty(t, objs)
+	})
+
+	t.Run("invalid YAML returns error", func(t *testing.T) {
+		_, err := LoadData(strings.NewReader("{{invalid"))
+		require.Error(t, err)
+	})
+
+	t.Run("normalizes integers to float64", func(t *testing.T) {
+		input := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+data:
+  replicas: 3
+`
+		objs, err := LoadData(strings.NewReader(input))
+		require.NoError(t, err)
+		require.Len(t, objs, 1)
+		data, _ := objs[0].Object["data"].(map[string]interface{})
+		if data != nil {
+			if v, ok := data["replicas"]; ok {
+				_, isFloat := v.(float64)
+				require.True(t, isFloat, "expected float64 after normalization, got %T", v)
+			}
+		}
+	})
+}


### PR DESCRIPTION


**Description**

Changes proposed in this pull request:

- Add normalizeToJSON helper that round-trips parsed YAML through JSON encoding/decoding. This ensures all numeric types become float64 (JSON-compatible), preventing panics in k8s.io/apimachinery's DeepCopyJSONValue which does not handle Go int values produced by the YAML decoder.
- Skip empty YAML documents (e.g. blank '---' separators) that would otherwise produce zero-value unstructured objects.

**From PR**
- #850 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- #831 

***PR1***