### PR TITLE
Downloading http-add-on

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,4 +1,6 @@
 images:
   - source: "ghcr.io/kedacore/keda:2.19.0"
-  - source: "ghcr.io/kedacore/keda-admission-webhooks:2.19.0"
   - source: "ghcr.io/kedacore/keda-metrics-apiserver:2.19.0"
+  - source: "ghcr.io/kedacore/http-add-on-scaler:0.12.2"
+  - source: "ghcr.io/kedacore/http-add-on-interceptor:0.12.2"
+  - source: "ghcr.io/kedacore/http-add-on-operator:0.12.2"

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -1,0 +1,128 @@
+// Package addon handles fetching and managing the KEDA HTTP add-on resources.
+package addon
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/kyma-project/keda-manager/pkg/yaml"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	tagsURL    = "https://api.github.com/repos/kedacore/http-add-on/tags"
+	releaseURL = "https://github.com/kedacore/http-add-on/releases/download/v%s/keda-add-ons-http-%s.yaml"
+	crdURL     = "https://github.com/kedacore/http-add-on/releases/download/v%s/keda-add-ons-http-%s-crds.yaml"
+
+	httpTimeout = 30 * time.Second
+)
+
+// versionRe validates a semver-like version without a leading "v".
+var versionRe = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+`)
+
+// NewHTTPClient returns an *http.Client that explicitly loads system CAs so TLS works in minimal (distroless) containers.
+func NewHTTPClient() (*http.Client, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load system CA pool: %w", err)
+	}
+	return &http.Client{
+		Timeout: httpTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: pool,
+			},
+		},
+	}, nil
+}
+
+// ValidateVersion trims a leading "v"/"V" and returns an error if the result
+// is not a valid semver string.
+func ValidateVersion(version string) (string, error) {
+	version = strings.TrimPrefix(strings.TrimPrefix(version, "v"), "V")
+	if !versionRe.MatchString(version) {
+		return "", fmt.Errorf("addon version %q is not a valid semver (expected format: MAJOR.MINOR.PATCH)", version)
+	}
+	return version, nil
+}
+
+// LatestVersion queries the GitHub tags API and returns the latest tag name
+// with the leading "v" stripped.
+func LatestVersion(client *http.Client) (string, error) {
+	resp, err := client.Get(tagsURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch tags: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("tags API returned HTTP %d", resp.StatusCode)
+	}
+
+	var tags []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		return "", fmt.Errorf("failed to decode tags response: %w", err)
+	}
+	if len(tags) == 0 {
+		return "", fmt.Errorf("no tags found for http-add-on")
+	}
+
+	tag := strings.TrimPrefix(tags[0].Name, "v")
+	return tag, nil
+}
+
+// FetchResources downloads the http-add-on CRDs and manifest for the given
+// version and parses them into unstructured objects. The CRDs are prepended so
+// they are applied before the rest of the resources.
+func FetchResources(client *http.Client, version string) ([]unstructured.Unstructured, error) {
+	version, err := ValidateVersion(version)
+	if err != nil {
+		return nil, err
+	}
+
+	crdObjs, err := fetchURL(client, fmt.Sprintf(crdURL, version, version), version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch addon CRDs: %w", err)
+	}
+
+	objs, err := fetchURL(client, fmt.Sprintf(releaseURL, version, version), version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch addon manifest: %w", err)
+	}
+
+	return append(crdObjs, objs...), nil
+}
+
+// fetchURL downloads a single URL and parses it into unstructured objects.
+func fetchURL(client *http.Client, url, version string) ([]unstructured.Unstructured, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download of %s returned HTTP %d for version %s", url, resp.StatusCode, version)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response from %s: %w", url, err)
+	}
+
+	objs, err := yaml.LoadData(strings.NewReader(string(body)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse response from %s: %w", url, err)
+	}
+
+	return objs, nil
+}

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -5,12 +5,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/kyma-project/keda-manager/pkg/yaml"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -20,28 +21,10 @@ const (
 	tagsURL    = "https://api.github.com/repos/kedacore/http-add-on/tags"
 	releaseURL = "https://github.com/kedacore/http-add-on/releases/download/v%s/keda-add-ons-http-%s.yaml"
 	crdURL     = "https://github.com/kedacore/http-add-on/releases/download/v%s/keda-add-ons-http-%s-crds.yaml"
-
-	httpTimeout = 30 * time.Second
 )
 
 // versionRe validates a semver-like version without a leading "v".
 var versionRe = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+`)
-
-// NewHTTPClient returns an *http.Client that explicitly loads system CAs so TLS works in minimal (distroless) containers.
-func NewHTTPClient() (*http.Client, error) {
-	pool, err := x509.SystemCertPool()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load system CA pool: %w", err)
-	}
-	return &http.Client{
-		Timeout: httpTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: pool,
-			},
-		},
-	}, nil
-}
 
 // ValidateVersion trims a leading "v"/"V" and returns an error if the result
 // is not a valid semver string.
@@ -51,6 +34,23 @@ func ValidateVersion(version string) (string, error) {
 		return "", fmt.Errorf("addon version %q is not a valid semver (expected format: MAJOR.MINOR.PATCH)", version)
 	}
 	return version, nil
+}
+
+// isTLSError checks if the error is related to TLS certificate verification.
+func isTLSError(err error) bool {
+	var certErr *tls.CertificateVerificationError
+	if errors.As(err, &certErr) {
+		return true
+	}
+	var unknownAuthErr x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuthErr) {
+		return true
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return isTLSError(urlErr.Err)
+	}
+	return false
 }
 
 // LatestVersion queries the GitHub tags API and returns the latest tag name
@@ -103,25 +103,28 @@ func FetchResources(client *http.Client, version string) ([]unstructured.Unstruc
 }
 
 // fetchURL downloads a single URL and parses it into unstructured objects.
-func fetchURL(client *http.Client, url, version string) ([]unstructured.Unstructured, error) {
-	resp, err := client.Get(url)
+func fetchURL(client *http.Client, rawURL, version string) ([]unstructured.Unstructured, error) {
+	resp, err := client.Get(rawURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to download %s: %w", url, err)
+		if isTLSError(err) {
+			return nil, fmt.Errorf("TLS certificate verification failed for %s: %w (ensure CA certificates are available in the container image)", rawURL, err)
+		}
+		return nil, fmt.Errorf("failed to download %s: %w", rawURL, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("download of %s returned HTTP %d for version %s", url, resp.StatusCode, version)
+		return nil, fmt.Errorf("download of %s returned HTTP %d for version %s", rawURL, resp.StatusCode, version)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response from %s: %w", url, err)
+		return nil, fmt.Errorf("failed to read response from %s: %w", rawURL, err)
 	}
 
 	objs, err := yaml.LoadData(strings.NewReader(string(body)))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse response from %s: %w", url, err)
+		return nil, fmt.Errorf("failed to parse response from %s: %w", rawURL, err)
 	}
 
 	return objs, nil

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -1,0 +1,207 @@
+package addon
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"plain semver", "0.13.0", "0.13.0", false},
+		{"with lowercase v", "v0.13.0", "0.13.0", false},
+		{"with uppercase V", "V1.2.3", "1.2.3", false},
+		{"invalid - text", "latest", "", true},
+		{"invalid - partial", "1.2", "", true},
+		{"invalid - empty", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateVersion(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLatestVersion(t *testing.T) {
+	t.Run("returns first tag stripped of v prefix", func(t *testing.T) {
+		tags := []struct {
+			Name string `json:"name"`
+		}{
+			{Name: "v0.13.0"},
+			{Name: "v0.12.2"},
+		}
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(tags)
+		}))
+		defer srv.Close()
+
+		// Override tagsURL via a test server - we need to use fetchURL-style approach
+		// Since tagsURL is a const, we test via httptest by patching the client
+		origURL := tagsURL
+		// We can't override const, so we test LatestVersion indirectly
+		// by using a custom transport that redirects
+		client := srv.Client()
+		transport := &urlRewriteTransport{
+			base:    client.Transport,
+			fromURL: origURL,
+			toURL:   srv.URL,
+		}
+		client.Transport = transport
+
+		version, err := LatestVersion(client)
+		require.NoError(t, err)
+		require.Equal(t, "0.13.0", version)
+	})
+
+	t.Run("error on empty tags", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]struct{}{})
+		}))
+		defer srv.Close()
+
+		client := srv.Client()
+		client.Transport = &urlRewriteTransport{
+			base:    client.Transport,
+			fromURL: tagsURL,
+			toURL:   srv.URL,
+		}
+
+		_, err := LatestVersion(client)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no tags found")
+	})
+
+	t.Run("error on non-200 status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		client := srv.Client()
+		client.Transport = &urlRewriteTransport{
+			base:    client.Transport,
+			fromURL: tagsURL,
+			toURL:   srv.URL,
+		}
+
+		_, err := LatestVersion(client)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "HTTP 500")
+	})
+}
+
+func TestFetchResources(t *testing.T) {
+	t.Run("invalid version returns error", func(t *testing.T) {
+		_, err := FetchResources(http.DefaultClient, "bad-version")
+		require.Error(t, err)
+	})
+
+	t.Run("fetches and parses CRDs and manifests", func(t *testing.T) {
+		crdYAML := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: httpscaledobjects.http.keda.sh
+`
+		manifestYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keda-add-ons-http-operator
+  namespace: keda
+`
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case contains(r.URL.Path, "crds"):
+				_, _ = w.Write([]byte(crdYAML))
+			default:
+				_, _ = w.Write([]byte(manifestYAML))
+			}
+		}))
+		defer srv.Close()
+
+		client := srv.Client()
+		client.Transport = &prefixRewriteTransport{
+			base:  client.Transport,
+			toURL: srv.URL,
+		}
+
+		objs, err := FetchResources(client, "0.13.0")
+		require.NoError(t, err)
+		require.Len(t, objs, 2)
+		// CRDs should come first
+		require.Equal(t, "CustomResourceDefinition", objs[0].GetKind())
+		require.Equal(t, "Deployment", objs[1].GetKind())
+	})
+
+	t.Run("error on CRD fetch failure", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		client := srv.Client()
+		client.Transport = &prefixRewriteTransport{base: client.Transport, toURL: srv.URL}
+
+		_, err := FetchResources(client, "0.13.0")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to fetch addon CRDs")
+	})
+}
+
+// urlRewriteTransport redirects requests from one URL to another for testing.
+type urlRewriteTransport struct {
+	base    http.RoundTripper
+	fromURL string
+	toURL   string
+}
+
+func (t *urlRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.String() == t.fromURL {
+		req = req.Clone(req.Context())
+		req.URL.Scheme = "http"
+		req.URL.Host = t.toURL[len("http://"):]
+		req.URL.Path = "/"
+	}
+	return t.base.RoundTrip(req)
+}
+
+// prefixRewriteTransport redirects all requests to a test server.
+type prefixRewriteTransport struct {
+	base  http.RoundTripper
+	toURL string
+}
+
+func (t *prefixRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.URL.Scheme = "http"
+	req.URL.Host = t.toURL[len("http://"):]
+	return t.base.RoundTrip(req)
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Add pkg/addon package for fetching, validating and downloading KEDA HTTP add-on manifests from GitHub releases.

**From PR**

- https://github.com/kyma-project/keda-manager/pull/850

**Related issue(s)**

- https://github.com/kyma-project/keda-manager/issues/831

***PR2***