### PR TITLE
sec: Remove unnecessary PR head checkout from compute-tags job

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -15,11 +15,6 @@ jobs:
     outputs:
       tags: ${{ steps.get_tag.outputs.TAGS }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - if: ${{ !startsWith(github.event_name, 'pull_request') }}
         name: Get the latest tag
         id: get_tag

--- a/.github/workflows/pull-release-1.9.yaml
+++ b/.github/workflows/pull-release-1.9.yaml
@@ -6,7 +6,6 @@ on:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
 permissions:
-  id-token: write # This is required for requesting the JWT token
   contents: read # This is required for actions/checkout
 
 jobs:
@@ -17,6 +16,9 @@ jobs:
     uses: kyma-project/keda-manager/.github/workflows/_gitleaks.yaml@release-1.9
 
   builds:
+    permissions:
+      id-token: write # This is required for requesting the JWT token
+      contents: read
     uses: kyma-project/keda-manager/.github/workflows/_build.yaml@release-1.9
 
   integrations:

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -6,7 +6,6 @@ on:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
 permissions:
-  id-token: write # This is required for requesting the JWT token
   contents: read # This is required for actions/checkout
 
 jobs:
@@ -22,6 +21,9 @@ jobs:
       ref: ${{ github.event.pull_request.head.sha }}
 
   builds:
+    permissions:
+      id-token: write # This is required for requesting the JWT token
+      contents: read
     uses: kyma-project/keda-manager/.github/workflows/_build.yaml@main
 
   integrations:


### PR DESCRIPTION
## Summary

- Removes an unnecessary `actions/checkout` of PR head code from the `compute-tags` job in `_build.yaml`
- The checkout fetched untrusted fork code in a `pull_request_target` context, but the only step that followed it was already skipped on PRs via `if: !startsWith(github.event_name, 'pull_request')`
- Eliminates an unnecessary attack surface — similar hardening was applied to `kyma-project/serverless` in PR #2521

## Test plan

- [ ] Verify PR-triggered builds still produce a correctly tagged image
- [ ] Verify push/release-triggered builds still compute and pass tags correctly