### PR TITLE
Fix Verify Addon instalation step in Integration test

### DIFF
--- a/hack/common/Makefile
+++ b/hack/common/Makefile
@@ -105,19 +105,21 @@ enable-addon: ## Enable HTTP add-on via annotations on Keda CR
 		--overwrite
 
 .PHONY: wait-for-addon-ready
-wait-for-addon-ready: ## Wait for addon deployments and pods to be ready
-	@echo "Waiting for addon deployments in namespace $(ADDON_NAMESPACE)..."
+wait-for-addon-ready: ## Wait for AddonInstalled condition to become True on Keda CR
+	@echo "Waiting for AddonInstalled condition to be True..."
 	@for i in $$(seq 1 30); do \
-		DEPLOYS=$$(kubectl get deploy -n $(ADDON_NAMESPACE) --no-headers 2>/dev/null | wc -l); \
-		if [ "$$DEPLOYS" -ge 3 ]; then \
-			echo "Found $$DEPLOYS deployments"; \
-			break; \
+		STATUS=$$(kubectl get keda default -n kyma-system -o jsonpath='{.status.conditions[?(@.type=="AddonInstalled")].status}' 2>/dev/null || echo ""); \
+		if [ "$$STATUS" = "True" ]; then \
+			echo "AddonInstalled condition is True"; \
+			exit 0; \
 		fi; \
-		echo "  attempt $$i: $$DEPLOYS deployments (3 expected)"; \
+		REASON=$$(kubectl get keda default -n kyma-system -o jsonpath='{.status.conditions[?(@.type=="AddonInstalled")].reason}' 2>/dev/null || echo ""); \
+		echo "  attempt $$i: AddonInstalled status=$$STATUS reason=$$REASON"; \
 		sleep 10; \
-	done
-	kubectl wait --for=condition=Available deployment --all -n $(ADDON_NAMESPACE) --timeout=200s
-	kubectl wait --for=condition=Ready pod --all -n $(ADDON_NAMESPACE) --timeout=200s
+	done; \
+	echo "ERROR: AddonInstalled condition did not become True within timeout"; \
+	kubectl get keda default -n kyma-system -o yaml; \
+	exit 1
 
 
 .PHONY: verify-addon-condition
@@ -137,19 +139,19 @@ disable-addon: ## Disable HTTP add-on via annotation
 		--overwrite
 
 .PHONY: wait-for-addon-removal
-wait-for-addon-removal: ## Wait for addon deployments to be removed
-	@echo "Waiting for addon removal from namespace $(ADDON_NAMESPACE)..."
+wait-for-addon-removal: ## Wait for HTTP addon deployments to be removed
+	@echo "Waiting for HTTP addon removal from namespace $(ADDON_NAMESPACE)..."
 	@for i in $$(seq 1 20); do \
-		DEPLOYS=$$(kubectl get deploy -n $(ADDON_NAMESPACE) --no-headers 2>/dev/null | wc -l); \
+		DEPLOYS=$$(kubectl get deploy -n $(ADDON_NAMESPACE) -l app.kubernetes.io/name=http-add-on --no-headers 2>/dev/null | wc -l); \
 		if [ "$$DEPLOYS" -eq 0 ]; then \
-			echo "All addon deployments removed"; \
+			echo "All HTTP addon deployments removed"; \
 			exit 0; \
 		fi; \
-		echo "  attempt $$i: $$DEPLOYS deployments still present"; \
+		echo "  attempt $$i: $$DEPLOYS HTTP addon deployments still present"; \
 		sleep 10; \
 	done; \
-	echo "ERROR: Addon deployments were not removed within timeout"; \
-	kubectl get deploy -n $(ADDON_NAMESPACE); \
+	echo "ERROR: HTTP addon deployments were not removed within timeout"; \
+	kubectl get deploy -n $(ADDON_NAMESPACE) -l app.kubernetes.io/name=http-add-on; \
 	exit 1
 
 .PHONY: verify-addon-disabled


### PR DESCRIPTION
wait-for-addon-ready now polls the AddonInstalled condition on the Keda CR instead of counting all deployments in kyma-system (which includes pre-existing keda-manager/keda-operator deployments that were always >= 3, causing the wait to exit before the controller had processed the addon annotation).

wait-for-addon-removal now filters deployments by the app.kubernetes.io/name=http-add-on label so it doesn't count the keda-manager deployment that is always present.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

**Related Issue**
https://github.com/kyma-project/keda-manager/issues/873