### PR TITLE
Add a gate that checks the type of contributor before running builds

### DIFF
--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -20,7 +20,15 @@ jobs:
     with:
       ref: ${{ github.event.pull_request.head.sha }}
 
+  select-environment:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
+    steps:
+      - name: Approved
+        run: echo "Build approved, environment selected"
+
   builds:
+    needs: select-environment
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Environment in context of this PR mean the environments configured in settings of this repository
External contributors require team member approval so if someone is not part of @kyma-project/otters and neither is owner of this repository he will fall under restricted environment and require our manual approval to proceed with builds, if a team member makes a contribution the build will run automatically cause it will fall into the "internal" environment

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
