### PR TITLE
Add logic to block disabling addon when httpscaledobject is present on cluster

### DIFF
--- a/api/v1alpha1/keda_types.go
+++ b/api/v1alpha1/keda_types.go
@@ -89,6 +89,7 @@ const (
 	ConditionReasonAddonDeleted    = "HTTPAddonDeleted"
 	ConditionReasonAddonInstallErr = "HTTPAddonInstallErr"
 	ConditionReasonAddonDisabled   = "HTTPAddonDisabled"
+	ConditionReasonAddonInUse      = "HTTPAddonInUse"
 
 	AnnotationAddonEnabled        = "keda.kyma-project.io/addon-enabled"
 	AnnotationAddonNamespace      = "keda.kyma-project.io/addon-namespace"

--- a/docs/user/07-10-http-add-on.md
+++ b/docs/user/07-10-http-add-on.md
@@ -78,7 +78,7 @@ kubectl get httpscaledobjects -A
 kubectl delete httpscaledobject -n <namespace> <name>
 ```
 
-Once all HTTPScaledObjects are gone, the Keda Manager retries automatically within about 30 seconds.
+Once all HTTPScaledObjects are deleted, the Keda Manager retries automatically within about 30 seconds.
 
 ## Configuring the HTTP Add-on
 

--- a/docs/user/07-10-http-add-on.md
+++ b/docs/user/07-10-http-add-on.md
@@ -65,6 +65,21 @@ kubectl annotate keda -n kyma-system default \
 
 This removes all add-on resources from the cluster. Only the resources managed by the HTTP Add-on are removed. Other workloads in the namespace are not affected.
 
+### Uninstall Protection
+
+The Keda Manager refuses to disable or uninstall the HTTP Add-on while any `HTTPScaledObject` resources exist on the cluster. This protects user workloads from losing their scaling controller and ending up with orphaned resources after the CRD is removed.
+
+If you try to disable the add-on or delete the Keda module CR while HTTPScaledObjects exist, the Keda CR's `Status.State` flips to `Warning` and the `Addon` condition is set to `False` with reason `HTTPAddonInUse`. The message tells you how many HTTPScaledObjects are blocking the uninstall.
+
+To find and remove them:
+
+```bash
+kubectl get httpscaledobjects -A
+kubectl delete httpscaledobject -n <namespace> <name>
+```
+
+Once all HTTPScaledObjects are gone, the Keda Manager retries automatically within about 30 seconds.
+
 ## Configuring the HTTP Add-on
 
 The HTTP Add-on components are configured using environment variables on their Deployments. You can customize them by patching the respective Deployment after installation.

--- a/docs/user/07-10-http-add-on.md
+++ b/docs/user/07-10-http-add-on.md
@@ -67,7 +67,7 @@ This removes all add-on resources from the cluster. Only the resources managed b
 
 ### Uninstall Protection
 
-The Keda Manager refuses to disable or uninstall the HTTP Add-on while any `HTTPScaledObject` resources exist on the cluster. This protects user workloads from losing their scaling controller and ending up with orphaned resources after the CRD is removed.
+The Keda Manager refuses to disable or uninstall the HTTP Add-on while any `HTTPScaledObject` resources exist in the cluster. This protects user workloads from losing their scaling controller and ending up with orphaned resources after the CRD is removed.
 
 If you try to disable the add-on or delete the Keda module CR while HTTPScaledObjects exist, the Keda CR's `Status.State` flips to `Warning` and the `Addon` condition is set to `False` with reason `HTTPAddonInUse`. The message tells you how many HTTPScaledObjects are blocking the uninstall.
 

--- a/pkg/reconciler/addon.go
+++ b/pkg/reconciler/addon.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/kyma-project/keda-manager/api/v1alpha1"
 	"github.com/kyma-project/keda-manager/pkg/addon"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +42,12 @@ const (
 	istioSidecarInjectAnnotation       = "sidecar.istio.io/inject"
 	kymaModuleLabel                    = "kyma-project.io/module"
 	kymaModuleLabelValue               = "keda"
+
+	httpScaledObjectGroup   = "http.keda.sh"
+	httpScaledObjectVersion = "v1alpha1"
+	httpScaledObjectKind    = "HTTPScaledObject"
+
+	guardAddonInUseRequeue = 30 * time.Second
 )
 
 var namespaceEnvVars = map[string]struct{}{
@@ -224,9 +233,54 @@ func deleteObjects(ctx context.Context, r *fsm, objs []unstructured.Unstructured
 func sFnHandleAddon(_ context.Context, _ *fsm, s *systemState) (stateFn, *ctrl.Result, error) {
 	cfg := v1alpha1.ReadAddonCfg(&s.instance)
 	if !cfg.Enabled {
-		return switchState(sFnDeleteAddon)
+		return switchState(sFnGuardAddonInUse)
 	}
 	return switchState(sFnApplyAddon)
+}
+
+// httpScaledObjectsInUse returns the number of HTTPScaledObjects on the
+// cluster. A missing CRD (NoKindMatchError / IsNotFound) returns (0, nil) —
+// there is nothing to block because the type doesn't exist. RBAC / API errors
+// are returned to the caller so they can surface a Warning and requeue.
+func httpScaledObjectsInUse(ctx context.Context, c client.Client) (int, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   httpScaledObjectGroup,
+		Version: httpScaledObjectVersion,
+		Kind:    httpScaledObjectKind + "List",
+	})
+	if err := c.List(ctx, list); err != nil {
+		if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("list HTTPScaledObjects: %w", err)
+	}
+	return len(list.Items), nil
+}
+
+// sFnGuardAddonInUse blocks the disable path of the HTTP add-on while at least
+// one HTTPScaledObject exists on the cluster. The user must remove their
+// HTTPScaledObjects before the add-on can be uninstalled — otherwise removing
+// the CRD would leave orphaned resources of an unknown type.
+func sFnGuardAddonInUse(ctx context.Context, r *fsm, s *systemState) (stateFn, *ctrl.Result, error) {
+	count, err := httpScaledObjectsInUse(ctx, r.Client)
+	if err != nil {
+		msg := fmt.Sprintf("Cannot verify HTTPScaledObject usage: %v", err)
+		v1alpha1.SetAddonCondition(&s.instance, metav1.ConditionFalse,
+			v1alpha1.ConditionReasonAddonInUse, msg)
+		s.instance.Status.State = v1alpha1.StateWarning
+		return stopWithRequeueAfter(guardAddonInUseRequeue)
+	}
+	if count == 0 {
+		return switchState(sFnDeleteAddon)
+	}
+	msg := fmt.Sprintf(
+		"%d HTTPScaledObject(s) still exist on the cluster; delete them before disabling the HTTP add-on",
+		count)
+	v1alpha1.SetAddonCondition(&s.instance, metav1.ConditionFalse,
+		v1alpha1.ConditionReasonAddonInUse, msg)
+	s.instance.Status.State = v1alpha1.StateWarning
+	return stopWithRequeueAfter(guardAddonInUseRequeue)
 }
 
 func sFnApplyAddon(ctx context.Context, r *fsm, s *systemState) (stateFn, *ctrl.Result, error) {

--- a/pkg/reconciler/addon_test.go
+++ b/pkg/reconciler/addon_test.go
@@ -2,12 +2,19 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/kyma-project/keda-manager/api/v1alpha1"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestReadAddonCfg(t *testing.T) {
@@ -430,14 +437,14 @@ func TestPatchDeploymentEnvNamespace(t *testing.T) {
 }
 
 func TestSFnHandleAddon(t *testing.T) {
-	t.Run("disabled addon switches to delete", func(t *testing.T) {
+	t.Run("disabled addon switches to guard", func(t *testing.T) {
 		s := &systemState{instance: v1alpha1.Keda{ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{v1alpha1.AnnotationAddonEnabled: "false"},
 		}}}
 		fn, result, err := sFnHandleAddon(context.TODO(), nil, s)
 		require.NoError(t, err)
 		require.Nil(t, result)
-		require.NotNil(t, fn)
+		requireEqualFunc(t, sFnGuardAddonInUse, fn)
 	})
 	t.Run("enabled addon switches to apply", func(t *testing.T) {
 		s := &systemState{instance: v1alpha1.Keda{ObjectMeta: metav1.ObjectMeta{
@@ -446,6 +453,125 @@ func TestSFnHandleAddon(t *testing.T) {
 		fn, result, err := sFnHandleAddon(context.TODO(), nil, s)
 		require.NoError(t, err)
 		require.Nil(t, result)
-		require.NotNil(t, fn)
+		requireEqualFunc(t, sFnApplyAddon, fn)
+	})
+}
+
+func newHTTPScaledObject(namespace, name string) *unstructured.Unstructured {
+	hso := &unstructured.Unstructured{}
+	hso.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   httpScaledObjectGroup,
+		Version: httpScaledObjectVersion,
+		Kind:    httpScaledObjectKind,
+	})
+	hso.SetNamespace(namespace)
+	hso.SetName(name)
+	return hso
+}
+
+func TestHTTPScaledObjectsInUse(t *testing.T) {
+	t.Run("returns zero when no HTTPScaledObjects exist", func(t *testing.T) {
+		c := fake.NewClientBuilder().Build()
+		count, err := httpScaledObjectsInUse(context.Background(), c)
+		require.NoError(t, err)
+		require.Equal(t, 0, count)
+	})
+	t.Run("counts all HTTPScaledObjects across namespaces", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithObjects(
+			newHTTPScaledObject("ns-a", "foo"),
+			newHTTPScaledObject("ns-a", "bar"),
+			newHTTPScaledObject("ns-b", "baz"),
+		).Build()
+		count, err := httpScaledObjectsInUse(context.Background(), c)
+		require.NoError(t, err)
+		require.Equal(t, 3, count)
+	})
+	t.Run("treats NoKindMatchError as zero", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: httpScaledObjectGroup, Kind: httpScaledObjectKind}}
+			},
+		}).Build()
+		count, err := httpScaledObjectsInUse(context.Background(), c)
+		require.NoError(t, err)
+		require.Equal(t, 0, count)
+	})
+	t.Run("treats IsNotFound as zero", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return apierrors.NewNotFound(schema.GroupResource{Group: httpScaledObjectGroup, Resource: "httpscaledobjects"}, "")
+			},
+		}).Build()
+		count, err := httpScaledObjectsInUse(context.Background(), c)
+		require.NoError(t, err)
+		require.Equal(t, 0, count)
+	})
+	t.Run("surfaces other list errors (fail-closed)", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return apierrors.NewForbidden(schema.GroupResource{Group: httpScaledObjectGroup, Resource: "httpscaledobjects"}, "", errors.New("rbac"))
+			},
+		}).Build()
+		_, err := httpScaledObjectsInUse(context.Background(), c)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "list HTTPScaledObjects")
+	})
+}
+
+// noKindMatchErr removed — we use meta.NoKindMatchError directly in the tests
+// above.
+func TestSFnGuardAddonInUse(t *testing.T) {
+	t.Run("no HTTPScaledObjects → switches to delete", func(t *testing.T) {
+		c := fake.NewClientBuilder().Build()
+		r := &fsm{K8s: K8s{Client: c}}
+		s := &systemState{instance: v1alpha1.Keda{}}
+
+		fn, result, err := sFnGuardAddonInUse(context.Background(), r, s)
+		require.NoError(t, err)
+		require.Nil(t, result)
+		requireEqualFunc(t, sFnDeleteAddon, fn)
+	})
+	t.Run("HTTPScaledObjects exist → warning + requeue", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithObjects(
+			newHTTPScaledObject("demo-app", "http-echo"),
+			newHTTPScaledObject("billing", "api"),
+		).Build()
+		r := &fsm{K8s: K8s{Client: c}}
+		s := &systemState{instance: v1alpha1.Keda{}}
+
+		_, _, err := sFnGuardAddonInUse(context.Background(), r, s)
+		require.NoError(t, err)
+		require.Equal(t, v1alpha1.StateWarning, s.instance.Status.State)
+		cond := metav1.Condition{}
+		for _, c := range s.instance.Status.Conditions {
+			if c.Reason == v1alpha1.ConditionReasonAddonInUse {
+				cond = c
+				break
+			}
+		}
+		require.Equal(t, v1alpha1.ConditionReasonAddonInUse, cond.Reason)
+		require.Equal(t, metav1.ConditionFalse, cond.Status)
+		require.Contains(t, cond.Message, "2 HTTPScaledObject(s)")
+	})
+	t.Run("list error → warning + requeue with verification message", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return apierrors.NewForbidden(schema.GroupResource{Group: httpScaledObjectGroup, Resource: "httpscaledobjects"}, "", errors.New("rbac"))
+			},
+		}).Build()
+		r := &fsm{K8s: K8s{Client: c}}
+		s := &systemState{instance: v1alpha1.Keda{}}
+
+		_, _, err := sFnGuardAddonInUse(context.Background(), r, s)
+		require.NoError(t, err)
+		require.Equal(t, v1alpha1.StateWarning, s.instance.Status.State)
+		var found bool
+		for _, c := range s.instance.Status.Conditions {
+			if c.Reason == v1alpha1.ConditionReasonAddonInUse {
+				require.Contains(t, c.Message, "Cannot verify HTTPScaledObject usage")
+				found = true
+			}
+		}
+		require.True(t, found)
 	})
 }

--- a/pkg/reconciler/delete_resources.go
+++ b/pkg/reconciler/delete_resources.go
@@ -76,12 +76,38 @@ func sFnUpstreamDeletionState(ctx context.Context, r *fsm, s *systemState) (stat
 }
 
 func sFnSafeDeletionState(ctx context.Context, r *fsm, s *systemState) (stateFn, *ctrl.Result, error) {
+	if err := checkAddonOrphanResources(ctx, r); err != nil {
+		s.instance.UpdateStateFromWarning(v1alpha1.ConditionTypeDeleted, v1alpha1.ConditionReasonAddonInUse, err)
+		return stopWithErrorAndNoRequeue(err)
+	}
+
 	if err := checkCRDOrphanResources(ctx, r); err != nil {
 		s.instance.UpdateStateFromWarning(v1alpha1.ConditionTypeDeleted, v1alpha1.ConditionReasonDeletionErr, err)
 		return stopWithErrorAndNoRequeue(err)
 	}
 
 	return deleteResourcesWithFilter(ctx, r, s)
+}
+
+// checkAddonOrphanResources refuses to tear down the HTTP add-on while there
+// are HTTPScaledObjects on the cluster. The add-on owns the HTTPScaledObject
+// CRD, so removing the add-on before the user removes their HTTPScaledObjects
+// would leave orphaned resources of an unknown type. The check is a no-op when
+// the add-on was never installed (r.AddonObjs is empty).
+func checkAddonOrphanResources(ctx context.Context, r *fsm) error {
+	if len(r.AddonObjs) == 0 {
+		return nil
+	}
+	count, err := httpScaledObjectsInUse(ctx, r.Client)
+	if err != nil {
+		return fmt.Errorf("cannot verify HTTPScaledObject usage: %w", err)
+	}
+	if count > 0 {
+		return fmt.Errorf(
+			"%d HTTPScaledObject(s) still exist on the cluster; delete them before uninstalling the Keda module",
+			count)
+	}
+	return nil
 }
 
 func withoutCRDFilter(u unstructured.Unstructured) bool {

--- a/pkg/reconciler/delete_resources_test.go
+++ b/pkg/reconciler/delete_resources_test.go
@@ -413,3 +413,39 @@ func canGetFakeResource(c client.Client, u unstructured.Unstructured) bool {
 		}, &u)
 	return err == nil
 }
+
+func TestCheckAddonOrphanResources(t *testing.T) {
+	t.Run("no add-on installed → no-op", func(t *testing.T) {
+		c := fake.NewClientBuilder().Build()
+		r := &fsm{
+			log: zap.NewNop().Sugar(),
+			K8s: K8s{Client: c},
+			Cfg: Cfg{},
+		}
+		require.NoError(t, checkAddonOrphanResources(context.Background(), r))
+	})
+	t.Run("add-on installed, no HTTPScaledObjects → pass", func(t *testing.T) {
+		c := fake.NewClientBuilder().Build()
+		r := &fsm{
+			log: zap.NewNop().Sugar(),
+			K8s: K8s{Client: c},
+			Cfg: Cfg{AddonObjs: []unstructured.Unstructured{{}}},
+		}
+		require.NoError(t, checkAddonOrphanResources(context.Background(), r))
+	})
+	t.Run("add-on installed, HTTPScaledObjects exist → error", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithObjects(
+			newHTTPScaledObject("demo-app", "http-echo"),
+			newHTTPScaledObject("billing", "api"),
+		).Build()
+		r := &fsm{
+			log: zap.NewNop().Sugar(),
+			K8s: K8s{Client: c},
+			Cfg: Cfg{AddonObjs: []unstructured.Unstructured{{}}},
+		}
+		err := checkAddonOrphanResources(context.Background(), r)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "2 HTTPScaledObject(s)")
+		require.Contains(t, err.Error(), "uninstalling the Keda module")
+	})
+}


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Add logic to block disabling addon when httpscaledobject is present on cluster
- Adjust docs to have info about this logic

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- #934